### PR TITLE
Require Rust toolchain 1.58 or greater

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ name = "embuild"
 version = "0.29.1"
 authors = ["Ivan Markov <ivan.markov@gmail.com>", "Dominik Gschwind <dominik.gschwind99@gmail.com>"]
 edition = "2021"
+rust-version = "1.58"
 categories = ["embedded", "development-tools::build-utils"]
 keywords = ["cargo", "platformio", "build-dependencies"]
 description = "A build support library for embedded Rust"


### PR DESCRIPTION
This specifies a minimum requirement for the Rust toolchain. If a user tries to compile `embuild` with a Rust toolchain that is too old, compilation will fail with:
```
% cargo build --features espidf
error: package `embuild v0.29.1 (~/src/embuild)` cannot be built because it requires rustc 1.58 or newer, while the currently active rustc version is 1.57.0
```

Note that the [rust-version field](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field) is only enforced in Rust toolchains version 1.56 and newer.