### PR TITLE
Update embuild version in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "embuild"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "anyhow",
  "bindgen",


### PR DESCRIPTION
Both the `cargo-pio` and `ldproxy` packages depend on `embuild`. When the version of `embuild` is updated, `Cargo.lock` will change to capture this new requirement.

I didn't run `cargo update` - that introduces quite a few changes - but I can add that to this PR if that is useful.

Thanks!