### PR TITLE
Fix git error when LANGUAGE is defined

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -16,7 +16,7 @@ pub const GIT: &str = "git";
 
 /// This is a workaround for setting the locale to `C` which guarantees that the output
 /// will be in english.
-const LC_ALL: [(&str, &str); 1] = [("LC_ALL", "C.UTF-8")];
+const LC_ALL: [(&str, &str); 2] = [("LC_ALL", "C.UTF-8"), ("LANGUAGE", "")];
 
 /// A logical git repository which may or may not exist.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
`LC_ALL` gets overridden by `LANGUAGE` environment variable, breaking the parsing of git output. See [gettext manual](http://www.gnu.org/software/gettext/manual/html_node/The-LANGUAGE-variable.html#The-LANGUAGE-variable). Notice that `LC_ALL=C` is not overridden, but other locales are, including `C.UTF-8`.

The solution clears `LANGUAGE`. Alternatively, `LC_ALL` could be changed to `LC_ALL=C`. As a workaround, the same effect can be achieved by adding
```
[env]
LANGUAGE = { value = "", force = true }
``` 
to the configuration file (`.cargo/config.toml`).