### PR TITLE
Fix issue where writing permissions while the file is open fails

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -92,13 +92,12 @@ pub fn is_file_eq(file: &File, other: &File) -> Result<bool> {
 pub fn copy_with_metadata(src_file: impl AsRef<Path>, dest_file: impl AsRef<Path>) -> Result<()> {
     fs::copy(&src_file, &dest_file)?;
     let src_fd = fs::File::open(&src_file)?;
-    let dest_fd = fs::File::open(&dest_file)?;
     let src_file_meta = src_fd.metadata()?;
 
     let src_atime = filetime::FileTime::from_last_access_time(&src_file_meta);
     let src_mtime = filetime::FileTime::from_last_modification_time(&src_file_meta);
 
-    dest_fd.set_permissions(src_file_meta.permissions())?;
+    fs::set_permissions(dest_file.as_ref(), src_file_meta.permissions())?;
     filetime::set_file_times(dest_file, src_atime, src_mtime)?;
 
     Ok(())


### PR DESCRIPTION
Fix an issue where permissions cannot be written to files while they are still open under windows.
Presents as "Error: Access is denied. (os error 5)"

- Causes issues downstream in esp-idf-sys when compiling under windows. See https://stackoverflow.com/questions/72969132/access-denied-when-building-esp-idf-sys-for-rust-project-for-esp32-on-windows-10