### PR TITLE
Fix CI warnings

### DIFF
--- a/.github/workflows/arm_linux_package.yml
+++ b/.github/workflows/arm_linux_package.yml
@@ -35,19 +35,16 @@ jobs:
           export TARGET_CC=clang-14
           export TARGET_AR=llvm-ar-14
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly
-          override: true
           target: ${{ inputs.target }}
 
       - uses: Swatinem/rust-cache@v1
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          use-cross: true
-          args: --release --all --target ${{ inputs.target }}
+      - run: cargo install cross
+
+      - run: cross build --release --all --target ${{ inputs.target }}
 
       - uses: papeloto/action-zip@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,10 @@ jobs:
       - name: Setup | Checkout
         uses: actions/checkout@v2
       - name: Setup | Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
-          components: rustfmt, clippy
-      - name: Setup | Std
-        run: rustup component add rust-src --toolchain stable-x86_64-unknown-linux-gnu
-      - name: Setup | Default to stable
-        run: rustup default stable
+          components: rustfmt, clippy, rust-src
       - name: Build | Fmt Check
         run: cargo fmt -- --check
       - name: Build | Clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup | Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup | Rust
         uses: dtolnay/rust-toolchain@v1
         with:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -28,17 +28,14 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
           target: ${{ inputs.target }}
 
       - uses: Swatinem/rust-cache@v1
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --all --target ${{ inputs.target }}
+      - run: cargo build --release --all --target ${{ inputs.target }}
 
       - uses: papeloto/action-zip@v1
         with:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -26,7 +26,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install musl-tools libudev-dev
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: dtolnay/rust-toolchain@v1
         with:

--- a/.github/workflows/publish-cargo-pio-dry-run.yml
+++ b/.github/workflows/publish-cargo-pio-dry-run.yml
@@ -1,7 +1,6 @@
 name: PublishCargoPioDryRun
 
-on:
-  workflow_dispatch
+on: workflow_dispatch
 
 jobs:
   publishdryrun:
@@ -11,12 +10,9 @@ jobs:
       - name: Setup | Checkout
         uses: actions/checkout@v2
       - name: Setup | Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly
-      - name: Setup | Std
-        run: rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
-      - name: Setup | Default to nightly
-        run: rustup default nightly
+          components: rust-src
       - name: Build | Publish Dry Run
         run: cd cargo-pio; cargo publish --dry-run

--- a/.github/workflows/publish-cargo-pio-dry-run.yml
+++ b/.github/workflows/publish-cargo-pio-dry-run.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup | Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup | Rust
         uses: dtolnay/rust-toolchain@v1
         with:

--- a/.github/workflows/publish-cargo-pio.yml
+++ b/.github/workflows/publish-cargo-pio.yml
@@ -10,7 +10,7 @@ jobs:
       CRATE_NAME: cargo-pio
     steps:
       - name: Setup | Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup | Rust
         uses: dtolnay/rust-toolchain@v1
         with:

--- a/.github/workflows/publish-cargo-pio.yml
+++ b/.github/workflows/publish-cargo-pio.yml
@@ -1,7 +1,6 @@
 name: PublishCargoPio
 
-on:
-  workflow_dispatch
+on: workflow_dispatch
 
 jobs:
   publish:
@@ -13,15 +12,10 @@ jobs:
       - name: Setup | Checkout
         uses: actions/checkout@v2
       - name: Setup | Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly
-      - name: Setup | Std
-        run: rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
-      - name: Setup | Default to nightly
-        run: rustup default nightly
-      - name: Setup | Default to nightly
-        run: rustup default nightly
+          component: rust-src
       - name: Login
         run: cargo login ${{ secrets.crates_io_token }}
       - name: Build | Publish

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -1,7 +1,6 @@
 name: PublishDryRun
 
-on:
-  workflow_dispatch
+on: workflow_dispatch
 
 jobs:
   publishdryrun:
@@ -11,12 +10,9 @@ jobs:
       - name: Setup | Checkout
         uses: actions/checkout@v2
       - name: Setup | Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly
-      - name: Setup | Std
-        run: rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
-      - name: Setup | Default to nightly
-        run: rustup default nightly
+          components: rust-src
       - name: Build | Publish Dry Run
         run: cargo publish --dry-run

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup | Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup | Rust
         uses: dtolnay/rust-toolchain@v1
         with:

--- a/.github/workflows/publish-ldproxy-dry-run copy.yml
+++ b/.github/workflows/publish-ldproxy-dry-run copy.yml
@@ -1,7 +1,6 @@
 name: PublishLdProxyDryRun
 
-on:
-  workflow_dispatch
+on: workflow_dispatch
 
 jobs:
   publishdryrun:
@@ -11,12 +10,9 @@ jobs:
       - name: Setup | Checkout
         uses: actions/checkout@v2
       - name: Setup | Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly
-      - name: Setup | Std
-        run: rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
-      - name: Setup | Default to nightly
-        run: rustup default nightly
+          components: rust-src
       - name: Build | Publish Dry Run
         run: cd ldproxy; cargo publish --dry-run

--- a/.github/workflows/publish-ldproxy-dry-run copy.yml
+++ b/.github/workflows/publish-ldproxy-dry-run copy.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup | Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup | Rust
         uses: dtolnay/rust-toolchain@v1
         with:

--- a/.github/workflows/publish-ldproxy.yml
+++ b/.github/workflows/publish-ldproxy.yml
@@ -1,7 +1,6 @@
 name: PublishLdProxy
 
-on:
-  workflow_dispatch
+on: workflow_dispatch
 
 jobs:
   publish:
@@ -13,13 +12,10 @@ jobs:
       - name: Setup | Checkout
         uses: actions/checkout@v2
       - name: Setup | Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly
-      - name: Setup | Std
-        run: rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
-      - name: Setup | Default to nightly
-        run: rustup default nightly
+          components: rust-src
       - name: Login
         run: cargo login ${{ secrets.crates_io_token }}
       - name: Build | Publish

--- a/.github/workflows/publish-ldproxy.yml
+++ b/.github/workflows/publish-ldproxy.yml
@@ -10,7 +10,7 @@ jobs:
       CRATE_NAME: ldproxy
     steps:
       - name: Setup | Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup | Rust
         uses: dtolnay/rust-toolchain@v1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,6 @@
 name: Publish
 
-on:
-  workflow_dispatch
+on: workflow_dispatch
 
 jobs:
   publish:
@@ -13,13 +12,10 @@ jobs:
       - name: Setup | Checkout
         uses: actions/checkout@v2
       - name: Setup | Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly
-      - name: Setup | Std
-        run: rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
-      - name: Setup | Default to nightly
-        run: rustup default nightly
+          components: rust-src
       - name: Setup | Default to nightly
         run: rustup default nightly
       - name: Login

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
       CRATE_NAME: embuild
     steps:
       - name: Setup | Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup | Rust
         uses: dtolnay/rust-toolchain@v1
         with:


### PR DESCRIPTION
- Replace `actions-rs/toolchain` by `dtolnay/rust-toolchain`
- Avoid using `actions-rs/cargo`
- Remove unecesary steps