### PR TITLE
Fix cmake for macos-arm64

### DIFF
--- a/src/espidf/resources/cmake.json
+++ b/src/espidf/resources/cmake.json
@@ -29,7 +29,8 @@
                         ]
                     ],
                     "platforms": [
-                        "macos"
+                        "macos",
+                        "macos-arm64"
                     ]
                 }
             ],
@@ -60,6 +61,11 @@
                         "url": "https://dl.espressif.com/dl/cmake/cmake-3.20.3-Linux-armv7l.tar.gz"
                     },
                     "macos": {
+                        "sha256": "5f72dba3aa5f3800fb29ab6115ae0b31f10bdb2aad66204e14c98f6ac7e6b6ed",
+                        "size": 66311879,
+                        "url": "https://github.com/Kitware/CMake/releases/download/v3.20.3/cmake-3.20.3-macos-universal.tar.gz"
+                    },
+                    "macos-arm64": {
                         "sha256": "5f72dba3aa5f3800fb29ab6115ae0b31f10bdb2aad66204e14c98f6ac7e6b6ed",
                         "size": 66311879,
                         "url": "https://github.com/Kitware/CMake/releases/download/v3.20.3/cmake-3.20.3-macos-universal.tar.gz"


### PR DESCRIPTION
# What changed?
- Added the `macos-arm64` platform to the cmake tools json.

# Why?
- Builds were failing on apple silicon macs due to there not being a `macos-arm64` platform entry in the cmake tools json.

# Notes
The same cmake package can be used as the intel macs since it's a "universal" package.

# Testing
Adding the following to my project's `Cargo.toml` fixed my build:
```toml
[patch.crates-io]
embuild = { git = "https://github.com/kylehendricks/embuild.git", branch = "fix-macos-arm64" }
```