### PR TITLE
Keep -isystem flags

### DIFF
--- a/src/espidf/ulp_fsm.rs
+++ b/src/espidf/ulp_fsm.rs
@@ -225,7 +225,6 @@ impl Builder {
                         .split_ascii_whitespace()
                         .filter_map(Self::unescape),
                 )
-                .flat_map(|s| iter::once("-I".to_owned()).chain(iter::once(s)))
                 .collect::<Vec<_>>(),
             SystemIncludes::MCU(ref mcu) => self
                 .add_includes
@@ -241,14 +240,17 @@ impl Builder {
     }
 
     fn unescape(arg: &str) -> Option<String> {
-        if arg.starts_with("\"-isystem") && arg.ends_with('\"') {
-            Some(arg[9..arg.len() - 1].replace("\\\"", "\""))
-        } else if arg.starts_with("-isystem") {
-            arg.strip_prefix("-isystem").map(|arg| arg.to_owned())
-        } else if arg.starts_with("\"-I") && arg.ends_with('\"') {
-            Some(arg[3..arg.len() - 1].replace("\\\"", "\""))
+        let unescaped;
+        if arg.starts_with("\"") && arg.ends_with('\"') {
+            unescaped = arg[1..arg.len() - 1].replace("\\\"", "\"");
         } else {
-            arg.strip_prefix("-I").map(|arg| arg.to_owned())
+            unescaped = arg.to_owned();
+        }
+
+        if unescaped.starts_with("-isystem") || unescaped.starts_with("-I") {
+            Some(unescaped)
+        } else {
+            None
         }
     }
 

--- a/src/espidf/ulp_fsm.rs
+++ b/src/espidf/ulp_fsm.rs
@@ -241,7 +241,11 @@ impl Builder {
     }
 
     fn unescape(arg: &str) -> Option<String> {
-        if arg.starts_with("\"-I") && arg.ends_with('\"') {
+        if arg.starts_with("\"-isystem") && arg.ends_with('\"') {
+            Some(arg[9..arg.len() - 1].replace("\\\"", "\""))
+        } else if arg.starts_with("-isystem") {
+            arg.strip_prefix("-isystem").map(|arg| arg.to_owned())
+        } else if arg.starts_with("\"-I") && arg.ends_with('\"') {
             Some(arg[3..arg.len() - 1].replace("\\\"", "\""))
         } else {
             arg.strip_prefix("-I").map(|arg| arg.to_owned())

--- a/src/espidf/ulp_fsm.rs
+++ b/src/espidf/ulp_fsm.rs
@@ -240,12 +240,11 @@ impl Builder {
     }
 
     fn unescape(arg: &str) -> Option<String> {
-        let unescaped;
-        if arg.starts_with("\"") && arg.ends_with('\"') {
-            unescaped = arg[1..arg.len() - 1].replace("\\\"", "\"");
+        let unescaped = if arg.starts_with('\"') && arg.ends_with('\"') {
+            arg[1..arg.len() - 1].replace("\\\"", "\"")
         } else {
-            unescaped = arg.to_owned();
-        }
+            arg.to_owned()
+        };
 
         if unescaped.starts_with("-isystem") || unescaped.starts_with("-I") {
             Some(unescaped)


### PR DESCRIPTION
Extend the ulp_fsm::Builder::escape function to keep includes starting with -isystem.