### PR TITLE
Fix clippy warning with 1.79.0 toolchain

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -78,11 +78,7 @@ impl Crate {
 
         cargo_toml.lib = Some(Product {
             crate_type: lib_type,
-            ..if let Some(p) = cargo_toml.lib.take() {
-                p
-            } else {
-                Default::default()
-            }
+            ..cargo_toml.lib.take().unwrap_or_default()
         });
 
         self.save_manifest(&cargo_toml)?;


### PR DESCRIPTION
The newest version of clippy catches a clippy::manual-unwrap-or-default issue, causing CI builds to fail.

This implements the recommended fix and therefore should fix the CI builds.