### PR TITLE
Support building with non-git repositories

### DIFF
--- a/src/espidf.rs
+++ b/src/espidf.rs
@@ -378,7 +378,7 @@ impl EspIdf {
         let idf_path = idf_path.map(Path::to_owned).ok_or(()).or_else(|()| {
             // detect repo from $IDF_PATH if not passed by caller
             env::var_os(IDF_PATH_VAR)
-                .map(|path| PathBuf::from(path))
+                .map(PathBuf::from)
                 .ok_or_else(|| {
                     FromEnvError::NoRepo(anyhow!("environment variable `{IDF_PATH_VAR}` not found"))
                 })

--- a/src/espidf.rs
+++ b/src/espidf.rs
@@ -354,12 +354,14 @@ pub struct EspIdf {
 #[derive(Debug, Clone)]
 pub enum SourceTree {
     Git(git::Repository),
+    Plain(PathBuf),
 }
 
 impl SourceTree {
     pub fn path(&self) -> &Path {
-        match tree {
+        match self {
             SourceTree::Git(repo) => repo.worktree(),
+            SourceTree::Plain(path) => path,
         }
     }
 }
@@ -371,11 +373,9 @@ impl EspIdf {
         let idf_path = env::var_os(IDF_PATH_VAR).ok_or_else(|| {
             FromEnvError::NoRepo(anyhow!("environment variable `{IDF_PATH_VAR}` not found"))
         })?;
-        let tree = match git::Repository::open(idf_path) {
+        let tree = match git::Repository::open(&idf_path) {
             Ok(repo) => SourceTree::Git(repo),
-            Err(e) => {
-                return Err(FromEnvError::NoRepo(e));
-            }
+            Err(_) => SourceTree::Plain(PathBuf::from(idf_path)),
         };
 
         let path_var = env::var_os("PATH").unwrap_or_default();

--- a/src/espidf.rs
+++ b/src/espidf.rs
@@ -379,7 +379,12 @@ impl EspIdf {
         let idf_path = env::var_os(IDF_PATH_VAR).ok_or_else(|| {
             FromEnvError::NoRepo(anyhow!("environment variable `{IDF_PATH_VAR}` not found"))
         })?;
-        let tree = SourceTree::open(Path::new(&idf_path));
+
+        let idf_absolute_path = crate::cargo::workspace_dir()
+            .map(|workspace| workspace.join(&idf_path))
+            .unwrap_or(PathBuf::from(idf_path));
+
+        let tree = SourceTree::open(&idf_absolute_path);
 
         let path_var = env::var_os("PATH").unwrap_or_default();
         let not_activated = |source: Error| -> FromEnvError {

--- a/src/espidf.rs
+++ b/src/espidf.rs
@@ -328,7 +328,7 @@ pub enum FromEnvError {
     #[error("`esp-idf` repository exists but required tools not in environment")]
     NotActivated {
         /// The esp-idf repository detected from the environment.
-        tree: SourceTree,
+        esp_idf_dir: SourceTree,
         /// The source error why detection failed.
         #[source]
         source: anyhow::Error,
@@ -339,15 +339,15 @@ pub enum FromEnvError {
 #[derive(Debug)]
 pub struct EspIdf {
     /// The esp-idf source tree.
-    pub tree: SourceTree,
+    pub esp_idf_dir: SourceTree,
     /// The binary paths of all tools concatenated with the system `PATH` env variable.
     pub exported_path: OsString,
     /// The path to the python executable to be used by the esp-idf.
     pub venv_python: PathBuf,
     /// The version of the esp-idf or [`Err`] if it could not be detected.
     pub version: Result<EspIdfVersion>,
-    /// Whether [`EspIdf::tree`] is a [`SourceTree::Git`] repository installed
-    /// and managed by [`Installer`] and **not** provided by the user.
+    /// Whether [`EspIdf::tree`] is a repository installed and managed by
+    /// [`Installer`] and **not** provided by the user.
     pub is_managed_espidf: bool,
 }
 
@@ -374,22 +374,22 @@ impl SourceTree {
 
 impl EspIdf {
     /// Try to detect an activated esp-idf environment.
-    pub fn try_from_env() -> Result<EspIdf, FromEnvError> {
-        // detect repo from $IDF_PATH
-        let idf_path = env::var_os(IDF_PATH_VAR).ok_or_else(|| {
-            FromEnvError::NoRepo(anyhow!("environment variable `{IDF_PATH_VAR}` not found"))
+    pub fn try_from_env(idf_path: Option<&Path>) -> Result<EspIdf, FromEnvError> {
+        let idf_path = idf_path.map(Path::to_owned).ok_or(()).or_else(|()| {
+            // detect repo from $IDF_PATH if not passed by caller
+            env::var_os(IDF_PATH_VAR)
+                .map(|path| PathBuf::from(path))
+                .ok_or_else(|| {
+                    FromEnvError::NoRepo(anyhow!("environment variable `{IDF_PATH_VAR}` not found"))
+                })
         })?;
 
-        let idf_absolute_path = crate::cargo::workspace_dir()
-            .map(|workspace| workspace.join(&idf_path))
-            .unwrap_or(PathBuf::from(idf_path));
-
-        let tree = SourceTree::open(&idf_absolute_path);
+        let esp_idf_dir = SourceTree::open(&idf_path);
 
         let path_var = env::var_os("PATH").unwrap_or_default();
         let not_activated = |source: Error| -> FromEnvError {
             FromEnvError::NotActivated {
-                tree: tree.clone(),
+                esp_idf_dir: esp_idf_dir.clone(),
                 source,
             }
         };
@@ -414,7 +414,7 @@ impl EspIdf {
         .map_err(not_activated)?;
 
         // make sure ${IDF_PATH}/tools/idf.py matches idf.py in $PATH
-        let idf_py_repo = path_buf![tree.path(), "tools", "idf.py"];
+        let idf_py_repo = path_buf![esp_idf_dir.path(), "tools", "idf.py"];
         match (idf_py.canonicalize(), idf_py_repo.canonicalize()) {
             (Ok(a), Ok(b)) if a != b => {
                 return Err(not_activated(anyhow!(
@@ -432,15 +432,16 @@ impl EspIdf {
         let python = which::which_in("python", Some(&path_var), "")
             .with_context(|| anyhow!("python not found in $PATH"))
             .map_err(not_activated)?;
-        let check_python_deps_py = path_buf![tree.path(), "tools", "check_python_dependencies.py"];
+        let check_python_deps_py =
+            path_buf![esp_idf_dir.path(), "tools", "check_python_dependencies.py"];
         cmd!(&python, &check_python_deps_py)
             .stdout()
             .with_context(|| anyhow!("failed to check python dependencies"))
             .map_err(not_activated)?;
 
         Ok(EspIdf {
-            version: EspIdfVersion::try_from(&tree),
-            tree,
+            version: EspIdfVersion::try_from(esp_idf_dir.path()),
+            esp_idf_dir,
             exported_path: path_var,
             venv_python: python,
             is_managed_espidf: true,
@@ -458,8 +459,8 @@ pub struct EspIdfVersion {
 
 impl EspIdfVersion {
     /// Try to extract the esp-idf version from an actual cloned repository.
-    pub fn try_from(tree: &SourceTree) -> Result<Self> {
-        let version_cmake = path_buf![tree.path(), "tools", "cmake", "version.cmake"];
+    pub fn try_from(esp_idf_dir: &Path) -> Result<Self> {
+        let version_cmake = path_buf![esp_idf_dir, "tools", "cmake", "version.cmake"];
 
         let base_err = || {
             anyhow!(
@@ -613,7 +614,7 @@ impl Installer {
             )
         })?;
 
-        let (tree, managed_repo) = match self.esp_idf_origin {
+        let (esp_idf_dir, managed_repo) = match self.esp_idf_origin {
             EspIdfOrigin::Managed(managed) => (
                 SourceTree::Git(managed.open_or_clone(
                     &install_dir,
@@ -626,7 +627,8 @@ impl Installer {
             EspIdfOrigin::Custom(tree) => (tree, false),
         };
         // Reading the version out of a cmake build file
-        let esp_version = EspIdfVersion::try_from(&tree)?;
+        let esp_version = EspIdfVersion::try_from(&esp_idf_dir.path())?;
+        let path_var_sep = if cfg!(windows) { ';' } else { ':' };
 
         // Create python virtualenv or use a previously installed one.
 
@@ -637,14 +639,14 @@ impl Installer {
         let python_version = python::check_python_at_least(3, 6)?;
 
         // Using the idf_tools.py script version that comes with the esp-idf git repository
-        let idf_tools_py = path_buf![tree.path(), "tools", "idf_tools.py"];
+        let idf_tools_py = path_buf![esp_idf_dir.path(), "tools", "idf_tools.py"];
 
         // TODO: add virtual_env check to skip install-python-env
         // running the command cost 2-3 seconds but always makes sure that everything is installed correctly and is up-to-date
 
         // assumes that the command can be run repeatedly
         // whenalready installed -> checks for updates and a working state
-        cmd!(PYTHON, &idf_tools_py, "--idf-path", tree.path(), "--non-interactive", "install-python-env";
+        cmd!(PYTHON, &idf_tools_py, "--idf-path", esp_idf_dir.path(), "--non-interactive", "install-python-env";
         env=(IDF_TOOLS_PATH_VAR, &install_dir), env_remove=("MSYSTEM"), env_remove=(IDF_PYTHON_ENV_PATH_VAR)).run()?;
 
         // since the above command exited sucessfully -> there should be a virt_env dir
@@ -675,7 +677,7 @@ impl Installer {
 
         let tools = self
             .tools_provider
-            .map(|p| p(&tree, &esp_version))
+            .map(|p| p(&esp_idf_dir, &esp_version))
             .unwrap_or(Ok(Vec::new()))?;
 
         let tools_wanted = tools.clone();
@@ -684,7 +686,7 @@ impl Installer {
             .flat_map(|tool| tool.tools.iter().map(|s| s.as_str()))
             .collect();
 
-        let tools_json = tree.path().join("tools/tools.json");
+        let tools_json = esp_idf_dir.path().join("tools/tools.json");
 
         let tools_vec = parse_tools(
             tools_wanted.clone(),
@@ -708,7 +710,7 @@ impl Installer {
                     .into_iter()
                     .flatten();
 
-                cmd!(&venv_python, &idf_tools_py, "--idf-path", tree.path(), @tools_json.clone(), "install"; 
+                cmd!(&venv_python, &idf_tools_py, "--idf-path", esp_idf_dir.path(), @tools_json.clone(), "install"; 
                      env=(IDF_TOOLS_PATH_VAR, &install_dir), args=(tool_set.tools)).run()?;
             }
 
@@ -743,7 +745,7 @@ impl Installer {
         log::debug!("Using PATH='{}'", &paths.to_string_lossy());
 
         Ok(EspIdf {
-            tree,
+            esp_idf_dir,
             exported_path: paths,
             venv_python,
             version: esp_version,

--- a/src/espidf.rs
+++ b/src/espidf.rs
@@ -358,6 +358,12 @@ pub enum SourceTree {
 }
 
 impl SourceTree {
+    pub fn open(path: &Path) -> Self {
+        git::Repository::open(path)
+            .map(SourceTree::Git)
+            .unwrap_or_else(|_| SourceTree::Plain(path.to_owned()))
+    }
+
     pub fn path(&self) -> &Path {
         match self {
             SourceTree::Git(repo) => repo.worktree(),
@@ -373,10 +379,7 @@ impl EspIdf {
         let idf_path = env::var_os(IDF_PATH_VAR).ok_or_else(|| {
             FromEnvError::NoRepo(anyhow!("environment variable `{IDF_PATH_VAR}` not found"))
         })?;
-        let tree = match git::Repository::open(&idf_path) {
-            Ok(repo) => SourceTree::Git(repo),
-            Err(_) => SourceTree::Plain(PathBuf::from(idf_path)),
-        };
+        let tree = SourceTree::open(Path::new(&idf_path));
 
         let path_var = env::var_os("PATH").unwrap_or_default();
         let not_activated = |source: Error| -> FromEnvError {

--- a/src/espidf.rs
+++ b/src/espidf.rs
@@ -625,8 +625,7 @@ impl Installer {
             EspIdfOrigin::Custom(tree) => (tree, false),
         };
         // Reading the version out of a cmake build file
-        let esp_version = EspIdfVersion::try_from(&esp_idf_dir.path())?;
-        let path_var_sep = if cfg!(windows) { ';' } else { ':' };
+        let esp_version = EspIdfVersion::try_from(esp_idf_dir.path())?;
 
         // Create python virtualenv or use a previously installed one.
 

--- a/src/espidf.rs
+++ b/src/espidf.rs
@@ -377,11 +377,9 @@ impl EspIdf {
     pub fn try_from_env(idf_path: Option<&Path>) -> Result<EspIdf, FromEnvError> {
         let idf_path = idf_path.map(Path::to_owned).ok_or(()).or_else(|()| {
             // detect repo from $IDF_PATH if not passed by caller
-            env::var_os(IDF_PATH_VAR)
-                .map(PathBuf::from)
-                .ok_or_else(|| {
-                    FromEnvError::NoRepo(anyhow!("environment variable `{IDF_PATH_VAR}` not found"))
-                })
+            env::var_os(IDF_PATH_VAR).map(PathBuf::from).ok_or_else(|| {
+                FromEnvError::NoRepo(anyhow!("environment variable `{IDF_PATH_VAR}` not found"))
+            })
         })?;
 
         let esp_idf_dir = SourceTree::open(&idf_path);

--- a/src/espidf.rs
+++ b/src/espidf.rs
@@ -524,7 +524,12 @@ impl std::fmt::Display for EspIdfVersion {
 /// - [`EspIdfOrigin::Custom`] values are designating a user-provided, already cloned
 ///   ESP-IDF repository which lives outisde the [`Installer`]'s installation directory. It is
 ///   only read by the [`Installer`] so as to install the required tooling.
-pub type EspIdfOrigin = git::sdk::SdkOrigin;
+pub enum EspIdfOrigin {
+    /// The [`Installer`] will install and manage the SDK.
+    Managed(git::sdk::RemoteSdk),
+    /// User-provided SDK repository untouched by the [`Installer`].
+    Custom(SourceTree),
+}
 
 /// A distinct version of the esp-idf repository to be installed.
 pub type EspIdfRemote = git::sdk::RemoteSdk;
@@ -610,7 +615,7 @@ impl Installer {
                 )?),
                 true,
             ),
-            EspIdfOrigin::Custom(repository) => (SourceTree::Git(repository), false),
+            EspIdfOrigin::Custom(tree) => (tree, false),
         };
         // Reading the version out of a cmake build file
         let esp_version = EspIdfVersion::try_from(&tree)?;

--- a/src/espidf.rs
+++ b/src/espidf.rs
@@ -346,8 +346,8 @@ pub struct EspIdf {
     pub venv_python: PathBuf,
     /// The version of the esp-idf or [`Err`] if it could not be detected.
     pub version: Result<EspIdfVersion>,
-    /// Whether [`EspIdf::repository`] is installed and managed by [`Installer`] and
-    /// **not** provided by the user.
+    /// Whether [`EspIdf::tree`] is a [`SourceTree::Git`] repository installed
+    /// and managed by [`Installer`] and **not** provided by the user.
     pub is_managed_espidf: bool,
 }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -505,30 +505,6 @@ pub mod sdk {
 
     use crate::git;
 
-    /// The origin of the SDK repository.
-    ///
-    /// Two variations exist:
-    /// - Managed
-    ///     The SDK source is installed automatically.
-    /// - Custom
-    ///     A user-provided local clone the SDK repository.
-    ///
-    /// In both cases the [`Installer`] will install all required tools.
-    ///
-    /// The main difference between managed and custom SDK origin is reflected in their naming:
-    /// - [`SdkOrigin::Managed`] values are cloned locally by the [`Installer`] instance, inside its tooling installation directory.
-    ///   Consenquently, these SDK repository clones will disappar if the installation directory is deleted by the user.
-    /// - [`SdkOrigin::Custom`] values are designating a user-provided, already cloned
-    ///   SDK repository which lives outisde the [`Installer`]'s installation directory. It is
-    ///   only read by the [`Installer`] so as to install the required tooling.
-    #[derive(Debug, Clone)]
-    pub enum SdkOrigin {
-        /// The [`Installer`] will install and manage the SDK.
-        Managed(RemoteSdk),
-        /// User-provided SDK repository untouched by the [`Installer`].
-        Custom(git::Repository),
-    }
-
     /// A distinct version of the SDK repository to be installed.
     #[derive(Debug, Clone)]
     pub struct RemoteSdk {


### PR DESCRIPTION
This is a repackaging of the work originally done in #80 and #82.

This allows `embuild` to build non-git source repositories. This work will allow dependencies (such was `esp-idf`) to be provided by sources other than `embuild` that may not include the surrounding `git` repo, such as the Nix package manager.

Reasonable testing has been completed in the [comment below](https://github.com/esp-rs/embuild/pull/95#issuecomment-2510228806).

Closes #80
Closes #81
Closes #82