### PR TITLE
Rename cargo-elfsize to just elfsize

### DIFF
--- a/.github/workflows/publish-elfsize-dry-run.yml
+++ b/.github/workflows/publish-elfsize-dry-run.yml
@@ -1,4 +1,4 @@
-name: PublishCargoElfsizeDryRun
+name: PublishElfsizeDryRun
 
 on: workflow_dispatch
 
@@ -15,4 +15,4 @@ jobs:
           toolchain: nightly
           components: rust-src
       - name: Build | Publish Dry Run
-        run: cd cargo-elfsize; cargo publish --dry-run
+        run: cd elfsize; cargo publish --dry-run

--- a/.github/workflows/publish-elfsize.yml
+++ b/.github/workflows/publish-elfsize.yml
@@ -1,4 +1,4 @@
-name: PublishCargoElfsize
+name: PublishElfsize
 
 on: workflow_dispatch
 
@@ -7,7 +7,7 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     env:
-      CRATE_NAME: cargo-elfsize
+      CRATE_NAME: elfsize
     steps:
       - name: Setup | Checkout
         uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- `cargo-elfsize` is renamed to `elfsize` and published under that name; it does not build
+  anything, so it should not have been a cargo subcommand. `cargo-elfsize` is yanked.
+
 ## [0.33.5] - 2026-09-07
 - `elfsize` module (feature `elf`): flash and RAM footprint of an ELF executable, and markdown
   reports comparing two builds, for firmware size tracking in CI

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["cargo-pio", "cargo-elfsize", "ldproxy"]
+members = ["cargo-pio", "elfsize", "ldproxy"]
 
 [package]
 name = "embuild"

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Other utilities that are not behind features include:
 
 ## Tools
 
-This repository also provides three CLI tools:
+This repository also provides these CLI tools:
 
 - [`cargo-pio`](cargo-pio)
 - [`ldproxy`](ldproxy)
-- [`cargo-elfsize`](cargo-elfsize)
+- [`elfsize`](elfsize)

--- a/elfsize/Cargo.toml
+++ b/elfsize/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "cargo-elfsize"
+name = "elfsize"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.74"
 authors = ["Ivan Markov <ivan.markov@gmail.com>"]
-categories = ["embedded", "development-tools::cargo-plugins"]
-keywords = ["cargo", "elf", "size", "bloat", "ci"]
-description = "Flash and RAM footprint reports for ELF firmware: a cargo subcommand"
+categories = ["embedded", "command-line-utilities", "development-tools"]
+keywords = ["elf", "size", "bloat", "firmware", "ci"]
+description = "Flash and RAM footprint reports for ELF firmware, for size tracking in CI"
 repository = "https://github.com/esp-rs/embuild"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/elfsize/README.md
+++ b/elfsize/README.md
@@ -1,17 +1,17 @@
-# cargo-elfsize
+# elfsize
 
 Prints the flash and RAM footprint of an ELF executable as a markdown table, or the
 difference between two builds of it. Meant for tracking firmware size in CI: build the
 firmware at the base commit and at the head of a pull request, then diff the two.
 
 ```
-cargo install cargo-elfsize
+cargo install elfsize
 
 # In every build job: measure the head build, or the base and the head builds
-cargo elfsize measure --label "basic_udp on esp32c6" --output esp32c6.json base.elf head.elf
+elfsize measure --label "basic_udp on esp32c6" --output esp32c6.json base.elf head.elf
 
 # In a final job: render all measurements as one report
-cargo elfsize report --warn 0.2 esp32c6.json nrf52840.json
+elfsize report --warn 0.2 esp32c6.json nrf52840.json
 ```
 
 produces
@@ -71,3 +71,6 @@ counting it would make every RAM delta zero.
 
 The same reports are available programmatically from the `embuild::elfsize` module
 (feature `elf`).
+
+The tool was briefly published as `cargo-elfsize`; that crate is yanked, as the tool does
+not build anything and should never have been a cargo subcommand.

--- a/elfsize/src/main.rs
+++ b/elfsize/src/main.rs
@@ -9,14 +9,8 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use embuild::elfsize::{Measurement, Report, Sizes, DEFAULT_RAM_SECTIONS};
 
-#[derive(Parser)]
-#[command(name = "cargo", bin_name = "cargo")]
-enum Cargo {
-    Elfsize(Args),
-}
-
 /// Flash and RAM footprint reports for ELF firmware
-#[derive(clap::Args)]
+#[derive(Parser)]
 #[command(version, arg_required_else_help = true)]
 struct Args {
     #[command(subcommand)]
@@ -62,9 +56,7 @@ enum Command {
 }
 
 fn main() -> Result<()> {
-    let Cargo::Elfsize(args) = Cargo::parse();
-
-    match args.command {
+    match Args::parse().command {
         Command::Measure {
             label,
             ram,


### PR DESCRIPTION
Subject says it all. `cargo elfsize` does not build anything, so having it named like that was wrong.